### PR TITLE
Add Bitcoin block hash to proof-of-freshness

### DIFF
--- a/utils/proof_of_freshness_generator.sh
+++ b/utils/proof_of_freshness_generator.sh
@@ -14,3 +14,4 @@ feedstail -1 -n5 -f {title} -u http://feeds.bbci.co.uk/news/world/rss.xml
 
 feedstail -1 -n5 -f {title} -u http://feeds.reuters.com/reuters/worldnews
 
+curl -s http://blockchain.info/blocks/?format=json | python3 -c "import sys, json; print(json.load(sys.stdin)['blocks'][10]['hash'])"


### PR DESCRIPTION
Solves https://github.com/QubesOS/qubes-issues/issues/2685

Apparently if you use python2 instead you need to set some UTF8 command line flag; grep | head | tail | cut would work too, but the set -x would leave a bunch of cruft on the output, and possibly better to actually parse the JSON rather than assuming blockchain.info doesn't change their format.

Also, the #/bin/sh at the top should be #/bin/bash, as only the latter supports \n in PS4; Debian at least doesn't have /bin/sh point to /bin/bash anymore.