### PR TITLE
Update QSB template

### DIFF
--- a/QSBs/qsb-template.txt
+++ b/QSBs/qsb-template.txt
@@ -5,31 +5,13 @@
 
                                 TODO
 
-User action required
----------------------
-
-Users must install the following specific packages in order to address
-the issues discussed in this bulletin:
-
-  For Qubes 4.0, in TODO:
-  - TODO
-
-  For Qubes 4.1, in TODO:
-  - TODO
-
-These packages will migrate from the security-testing repository to the
-current (stable) repository over the next two weeks after being tested
-by the community. [1] Once available, the packages are to be installed
-via the Qubes Update tool or its command-line equivalents. [2]
+User action
+------------
 
 TODO:
-Dom0 must be restarted afterward in order for the updates to take
-effect.
-
-TODO:
-If you use Anti Evil Maid, you will need to reseal your secret
-passphrase to new PCR values, as PCR18+19 will change due to the new
-Xen binaries.
+No special user action is required. Continue to update normally [1] in
+order to receive the security updates described in the "Patching"
+section below.
 
 Summary
 --------
@@ -41,6 +23,37 @@ Impact
 
 TODO
 
+Affected systems
+-----------------
+
+TODO
+
+Patching
+---------
+
+The following packages contain security updates that address the
+vulnerabilities described in this bulletin:
+
+  For Qubes 4.1, in TODO:
+  - TODO
+
+  For Qubes 4.2, in TODO:
+  - TODO
+
+These packages will migrate from the security-testing repository to the
+current (stable) repository over the next two weeks after being tested
+by the community. [2] Once available, the packages are to be installed
+via the Qubes Update tool or its command-line equivalents. [1]
+
+TODO:
+Dom0 must be restarted afterward in order for the updates to take
+effect.
+
+TODO:
+If you use Anti Evil Maid, you will need to reseal your secret
+passphrase to new PCR values, as PCR18+19 will change due to the new
+Xen binaries.
+
 Credits
 --------
 
@@ -49,8 +62,8 @@ TODO
 References
 -----------
 
-[1] https://www.qubes-os.org/doc/testing/
-[2] https://www.qubes-os.org/doc/how-to-update/
+[1] https://www.qubes-os.org/doc/how-to-update/
+[2] https://www.qubes-os.org/doc/testing/
 TODO
 
 --

--- a/QSBs/qsb-template.txt
+++ b/QSBs/qsb-template.txt
@@ -9,9 +9,9 @@ User action
 ------------
 
 TODO:
-No special user action is required. Continue to update normally [1] in
-order to receive the security updates described in the "Patching"
-section below.
+Continue to update normally [1] in order to receive the security updates
+described in the "Patching" section below. No other user action is required in
+response to this QSB.
 
 Summary
 --------


### PR DESCRIPTION
This PR (which replaces #45) aims to reduce user confusion caused by lengthy text after the list of packages ([example](https://forum.qubes-os.org/t/qsb-093-transient-execution-vulnerabilities-in-amd-and-intel-cpus-cve-2023-20569-xsa-434-cve-2022-40982-xsa-435/20299/3)). My proposal in #45 for bifurcating the first section solves this.

Here is the rationale I provided in #45 (edited for this PR):
> Separates the initial section into "User action" and "Patching." "User action" is for any special instructions that users must follow beyond updating the system normally. For most QSBs, it is not expected that there will be any such special instructions, so the default text provided here should suffice.
> 
> The "Patching" section is for advanced users who are interested in technical details about the packages or in testing them while they're in `security-testing`.

This bifurcation makes things much simpler and more user-friendly for the vast majority of users. #45 remained open for years because it was blocked by https://github.com/QubesOS/qubes-issues/issues/6692. This version, by contrast, makes sense today and can be merged immediately.

As for moving the "Patching" section all the way to the bottom: It doesn't have to be there. I don't have a strong opinion about its position, but the only reason we had it at the top was to have a "user action" statement first, which is now solved.

Also added an "affected systems" section, since (as @HW42 pointed out in private correspondence) we should've had it in previous QSBs, and XSAs have a similar section. Seems like we often need it, but I don't feel strongly about having it.

Let me know if the rationale for anything else is non-obvious, and I'll be happy to explain my reasoning.
